### PR TITLE
allow users to set config via cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+- Allow users to manage their configration via the cli [#2](https://github.com/mapbox/missed-issues/pull/2)
+
 # 1.0.0
 
 a cli tool and node module for finding issues that mention a team and no one from the team has responded to the issue

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ This will list all issues in the mapbox org that mention `@mapbox/teamname` wher
 - `--max-issues`: the max number of issues to get before filtering to help avoid long requests. Defaults to 100. That said, hitting this max is bad for your results.
 - `--nonmembers`: a comma-separated list of user logins who should not be used to count a ticket as replied too.
 
-## Environment Variables
+## Configuration
 
-`missed-issues` allows you to use environment variables to set unprovided flags. This is very helpful if you are running this for a single team or a single org and it lets you not paste your GitHub token into your terminal over and over again.
+`missed-issues` allows you to configure defaults for unprovided flags. This is very helpful if you are running this for a single team or a single org and it lets you not paste your GitHub token into your terminal over and over again.
+
+Configuration is powered by environment variables and can thus be set via your `.profile` or simular shell setup tool.
 
 Below is a list of env vars `missed-issues` supports. The value of the env var is the flag the key will set.
 
@@ -50,6 +52,41 @@ MISSED_ISSUES_IGNORE_REPOS=ignore-repos
 MISSED_ISSUES_NON_MEMBERS=nonmembers
 ```
 
-**.env files**
+### Viewing Configuration via the CLI
 
-If you have a `.env` file in the folder returned by `which missed-issues` then `missed-issues` will auto load these env vars on every run.
+`missed-issues config`
+
+This will print out of flags as set via environment variables and config.
+
+```sh
+Current configuration
+		token: fake-token
+		team: just-a-team
+		org: just-an-org
+		ignore-repos: <NOT SET>
+		nonmembers: <NOT SET>
+```
+
+`<NOT SET>` indicates that the value will not be set via the config or current environment variables.
+
+## Setting Configuration via the CLI
+
+`missed-issues config <flag> <value>`
+
+This commands sets the value of a flag perminitly in your `missed-issues` config file.
+
+**flags**
+
+The below flags can be stored
+
+- token
+- org
+- team
+- ignore-repos
+- nonmembers
+
+**values**
+
+All values should match that desribed in the flags section but validation is not provided at this step. The value must be set. To unset a flag try `missed-issues config <flag> ""`.
+
+

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
+
+// run config if requested
+if (process.argv[2] === 'config') {
+  require('./config');
+  process.exit();
+}
+
+// main program
 const path = require('path');
 require('dotenv').load(path.join(__dirname, '..', '.env'));
+
 const missedIssues = require('../index');
 
-var envFlags = {
-  token: 'GITHUB_TOKEN',
-  team: 'MISSED_ISSUES_TEAM',
-  org: 'MISSED_ISSUES_ORG',
-  'ignore-repos': 'MISSED_ISSUES_IGNORE_REPOS',
-  nonmembers: 'MISSED_ISSUES_NON_MEMBERS'
-};
+var envFlags = require('./flag-envs.json');
 
 // PROCESS ARGS
 const opts = process.argv.slice(2).reduce((m, v, i, a) => {

--- a/bin/config.js
+++ b/bin/config.js
@@ -1,0 +1,54 @@
+const path = require('path');
+const fs = require('fs');
+const dotenvFile = path.join(__dirname, '..', '.env');
+
+const envFlags = require('./flag-envs.json');
+var envValues;
+try {
+  envValues = fs
+    .readFileSync(dotenvFile)
+    .toString()
+    .split('\n')
+    .filter(l => l !== '')
+    .map(l => l.split('='))
+    .reduce((m, v) => {
+      m[v[0]] = v[1];
+      return m;
+    }, {});
+} catch (err) {
+  envValues = {};
+}
+
+if (process.argv.length === 3) {
+  // PRINT CONFIG
+  require('dotenv').load(dotenvFile);
+
+  console.log(`Current configuration`); // eslint-disable-line no-console
+  Object.keys(envFlags).forEach(flag => {
+    var env = envFlags[flag];
+    var val = envValues[env] || process.env[env] || '<NOT SET>';
+    console.log(`\t\t${flag}: ${val}`); // eslint-disable-line no-console
+  });
+  process.exit();
+}
+
+var flag = process.argv[3];
+var value = process.argv[4];
+
+if (envFlags[flag] === undefined) {
+  console.error('Unknown flag: ' + flag); // eslint-disable-line no-console
+  process.exit(1);
+}
+
+if (value === undefined) {
+  console.error('Value must be provided to set a flag'); // eslint-disable-line no-console
+  process.exit(1);
+}
+
+envValues[envFlags[flag]] = value;
+
+var fileStr = Object.keys(envValues).reduce((m, k) => {
+  return `${m}${k}=${envValues[k]}\n`;
+}, '');
+
+fs.writeFileSync(dotenvFile, fileStr);

--- a/bin/flag-envs.json
+++ b/bin/flag-envs.json
@@ -1,0 +1,7 @@
+{
+  "token": "GITHUB_TOKEN",
+  "team": "MISSED_ISSUES_TEAM",
+  "org": "MISSED_ISSUES_ORG",
+  "ignore-repos": "MISSED_ISSUES_IGNORE_REPOS",
+  "nonmembers": "MISSED_ISSUES_NON_MEMBERS"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mapbox/missed-issues",
+  "name": "missed-issues",
   "version": "1.0.0",
   "description":
     "Find all issues in a github org that mention a team by have not be replied to by the team members",
@@ -34,5 +34,6 @@
   "lint-staged": {
     "*.json": ["prettier --single-quote --write", "git add"],
     "*.js": ["eslint .", "prettier --single-quote --write", "git add"]
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Allow users to set and see the flags filled out by `.env` via `missed-issues config [flag flag-value]`

The README needs to merge before this so I can update the docs.