### PR TITLE
allow +1 reactions on an issue with no comments acknowledge the issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+- Support for 👍 reactions[#3](https://github.com/mapbox/missed-issues/pull/3)
+- Fix bug where `dotenv` was not in the package.json
+
 # 1.1.0
 
 - Allow users to manage their configration via the cli [#2](https://github.com/mapbox/missed-issues/pull/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.2.0
+# 1.2.0 (renamed to @mapbox/missed-issues)
 
 - Support for 👍 reactions[#3](https://github.com/mapbox/missed-issues/pull/3)
 - Fix bug where `dotenv` was not in the package.json

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A CLI tool for finding issues that mention a team and no one from the team has responded to the issue.
 
-
-This will list all issues in the mapbox org that mention `@mapbox/teamname` where no member of that team has replied to the issue since the mention.
+This will list all issues in the mapbox org that mention `@mapbox/teamname` where no member of that team has replied to the issue since the mention. To help cut down on commenting for commenting's sake, it also accepts 👍 on the original post as acknowledgement of the issue if no comments below mention the team.
 
 ```sh
 > missed-issues --org mapbox --team teamname --token github_token
@@ -21,7 +20,17 @@ This will list all issues in the mapbox org that mention `@mapbox/teamname` wher
 - [ ] [#42 - Document the node module interface](https://github.com/mapbox/missed-issues/issues/new)
 ```
 
-## Flags
+## Usage
+
+`npm install @mapbox/missed-issues -g`
+
+Go to [Personal access tokens](https://github.com/settings/tokens) in GitHub and create a token with `read:org` and `repo` access and than run the follow command. This will store your token in a config file so that you don't have to type `--token [redacted]` every time you run `missed-issues`.
+
+```
+missed-issues config token [redacted]`
+```
+
+## Command Options
 
 **Required**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mapbox/missed-issues",
+  "name": "missed-issues",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -453,6 +453,11 @@
         "esutils": "2.0.2",
         "isarray": "1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
     "elegant-spinner": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "missed-issues",
+  "name": "@mapbox/missed-issues",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -423,6 +423,15 @@
         "ms": "2.0.0"
       }
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved":
+        "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -458,6 +467,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -703,8 +717,17 @@
       "version": "3.0.0",
       "resolved":
         "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "gh-got": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+      "integrity":
+        "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+      "requires": {
+        "got": "7.1.0",
+        "is-plain-obj": "1.1.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -742,6 +765,28 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "got": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity":
+        "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "requires": {
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved":
@@ -763,6 +808,23 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.1",
+      "resolved":
+        "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity":
+        "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved":
+        "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity":
+        "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "husky": {
       "version": "0.14.3",
@@ -901,6 +963,11 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved":
@@ -928,6 +995,12 @@
         "path-is-inside": "1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved":
+        "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved":
@@ -951,11 +1024,16 @@
         "tryit": "1.0.3"
       }
     },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved":
+        "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "isarray": {
       "version": "1.0.0",
@@ -968,6 +1046,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity":
+        "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
+      }
     },
     "jest-get-type": {
       "version": "21.2.0",
@@ -1354,6 +1442,12 @@
         }
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved":
+        "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -1370,6 +1464,12 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved":
+        "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1577,11 +1677,17 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved":
+        "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity":
+        "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-map": {
       "version": "1.2.0",
@@ -1589,6 +1695,14 @@
       "integrity":
         "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
+    },
+    "p-timeout": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.0.tgz",
+      "integrity": "sha1-mCD5lDTFgXhotPNICe5SkWYNW2w=",
+      "requires": {
+        "p-finally": "1.0.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -1655,6 +1769,12 @@
         "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved":
+        "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
       "version": "1.8.2",
@@ -1826,8 +1946,7 @@
       "resolved":
         "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity":
-        "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+        "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
       "version": "5.4.1",
@@ -2009,6 +2128,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -2041,6 +2165,21 @@
         "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved":
+        "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved":
+        "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "*.js": ["eslint .", "prettier --single-quote --write", "git add"]
   },
   "dependencies": {
-    "dotenv": "^4.0.0"
+    "dotenv": "^4.0.0",
+    "gh-got": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,7 @@
     "*.json": ["prettier --single-quote --write", "git add"],
     "*.js": ["eslint .", "prettier --single-quote --write", "git add"]
   },
-  "dependencies": {}
+  "dependencies": {
+    "dotenv": "^4.0.0"
+  }
 }


### PR DESCRIPTION
Some tickets don't need comments to be acknowledged. Rather than just letting those tickets sit around, `missed-issues` allows you to 👍 a github ticket that has zero comments remove it from your queue.

This needs to merged after #1 as it needs to update the docs as well.

This also fixed #4